### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ we are using phenopackets version 2.0.2. openpyxl is needed to read Excel files.
 ```
 python3 -m venv venv
 source venv/bin/activate
-pip install phenopackets
-pip install pandas
-pip install openpyxl
-pip install jupyter
+pip install -r requirements.txt
 ipython kernel install --name "venv" --user
 cd notebooks
 jupyter-notebook

--- a/pyphetools/simple_column_mapper.py
+++ b/pyphetools/simple_column_mapper.py
@@ -26,12 +26,12 @@ def try_mapping_columns(df, observed, excluded, hpo_cr, preview=True):
         hpo_term = hpo_cr.parse_cell(col)
         if len(hpo_term) > 0:
             hpo_term = hpo_term[0]
-            simple_mappers[hpo_term.label] = SimpleColumnMapper(hpo_id=hpo_term.id,
+            simple_mappers[col] = SimpleColumnMapper(hpo_id=hpo_term.id,
                                                                 hpo_label=hpo_term.label,
                                                                 observed=observed,
                                                                 excluded=excluded)
             if preview:
-                print(simple_mappers[hpo_term.label].preview_column(df[col]))
+                print(simple_mappers[col].preview_column(df[col]))
         else:
             col_not_found.append(col)
     return simple_mappers, col_not_found

--- a/pyphetools/simple_column_mapper.py
+++ b/pyphetools/simple_column_mapper.py
@@ -2,10 +2,44 @@ from .hp_term import HpTerm
 from .column_mapper import ColumnMapper
 from typing import List
 import pandas as pd
+from collections import defaultdict
+
+
+def try_mapping_columns(df, observed, excluded, hpo_cr, preview=True):
+    """Try to map the columns in a dataframe by matching the name of the column to correct HPO term.
+    Wrapper for SimpleColumnMapper below
+
+    Args:
+       df (dataframe): dataframe with phenotypic data
+       observed (str): symbol used in table if the phenotypic feature was observed
+       excluded (str): symbol used if the feature was excluded
+       hpo_cr (HpoConceptRecognizer): instance of HpoConceptRecognizer to match HPO term and get label/id
+       preview (bool): whether to print the successfully mapped columns
+
+    Returns:
+        simple_mappers (dict): dict with successfully mapped columns
+        col_not_found (list): columns that were not mapped
+    """
+    col_not_found = []
+    simple_mappers = defaultdict(ColumnMapper)
+    for col in df.columns:
+        hpo_term = hpo_cr.parse_cell(col)
+        if len(hpo_term) > 0:
+            hpo_term = hpo_term[0]
+            simple_mappers[hpo_term.label] = SimpleColumnMapper(hpo_id=hpo_term.id,
+                                                                hpo_label=hpo_term.label,
+                                                                observed=observed,
+                                                                excluded=excluded)
+            if preview:
+                print(simple_mappers[hpo_term.label].preview_column(df[col]))
+        else:
+            col_not_found.append(col)
+    return simple_mappers, col_not_found
+
 
 class SimpleColumnMapper(ColumnMapper):
-    
-    def __init__(self, hpo_id, hpo_label, observed=None, excluded=None, non_measured = None, constant=False):
+
+    def __init__(self, hpo_id, hpo_label, observed=None, excluded=None, non_measured=None, constant=False):
         """_summary_
 
         Args:
@@ -20,7 +54,8 @@ class SimpleColumnMapper(ColumnMapper):
         self._hpo_label = hpo_label
         if observed is None or excluded is None:
             if not constant:
-                raise ValueError("constant argument must be true if not arguments are provided for observed and excluded")
+                raise ValueError(
+                    "constant argument must be true if not arguments are provided for observed and excluded")
         if constant:
             self._observed = set()
             self._excluded = set()
@@ -29,12 +64,13 @@ class SimpleColumnMapper(ColumnMapper):
             self._excluded = set(excluded)
         self._not_measured = non_measured
         self._constant = constant
-        
+
     def map_cell(self, cell_contents) -> List[HpTerm]:
         if self._constant:
             return [HpTerm(id=self._hpo_id, label=self._hpo_label)]
         if not isinstance(cell_contents, str):
-            raise ValueError(f"Error: cell_contents argument ({cell_contents}) must be string but was {type(cell_contents)} -- coerced to string")
+            raise ValueError(
+                f"Error: cell_contents argument ({cell_contents}) must be string but was {type(cell_contents)} -- coerced to string")
         contents = cell_contents.strip()
         if contents in self._observed:
             return [HpTerm(id=self._hpo_id, label=self._hpo_label)]
@@ -43,18 +79,12 @@ class SimpleColumnMapper(ColumnMapper):
         else:
             return [HpTerm(id=self._hpo_id, label=self._hpo_label, measured=False)]
 
-
     def preview_column(self, column) -> pd.DataFrame:
         if not isinstance(column, pd.Series):
             raise ValueError("column argument must be pandas Series, but was {type(column)}")
         dlist = []
         for _, value in column.items():
-            value  = self.map_cell(str(value))
+            value = self.map_cell(str(value))
             hpterm = value[0]
             dlist.append({"term": hpterm.hpo_term_and_id, "status": hpterm.display_value})
-        return pd.DataFrame(dlist)  
-    
-        
-        
-    
-
+        return pd.DataFrame(dlist)

--- a/pyphetools/simple_column_mapper.py
+++ b/pyphetools/simple_column_mapper.py
@@ -60,8 +60,8 @@ class SimpleColumnMapper(ColumnMapper):
             self._observed = set()
             self._excluded = set()
         else:
-            self._observed = set(observed)
-            self._excluded = set(excluded)
+            self._observed = observed
+            self._excluded = excluded
         self._not_measured = non_measured
         self._constant = constant
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ phenopackets
 pandas
 openpyxl
 jupyter
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+phenopackets
+pandas
+openpyxl
+jupyter


### PR DESCRIPTION
Some suggestions for (minor) improvements:

- ``try_mapping_columns`` tries to do the ``SimpleColumnMapper`` by inferring the HPO term from the column name, since I think for a large part, this will correspond correctly to the HPO label, so saves some work, by running this function first, you don't have to do it column for column (only for the ones that remain)
- there was a bug in ``SimpleColumnMapper`` , because it used ``set()``, that lead to some unwanted behaviour in the matching when ``observed`` is a string larger than 1. For instance, in my column, I wanted all entries with Severe to be positive, but it failed to matched first because ``observed`` became ``{'S', 'e', 'r', 'v'}``
- added a ``requirements.txt``

Hope this helps, if not, feel free to ignore these suggestions