### PR TITLE
Bug fix

### DIFF
--- a/pyphetools/creation/hpo_exact_cr.py
+++ b/pyphetools/creation/hpo_exact_cr.py
@@ -65,12 +65,8 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
     
     def _parse_chunk(self, chunk, custom_d) -> List[HpTerm]:
         if chunk in custom_d:
-            if 'hp' not in chunk:
-                hpo_id = custom_d.get(chunk)
-                label = self._id_to_primary_label[hpo_id]
-            else:
-                label = custom_d.get(chunk)
-                hpo_id = self._label_to_id[label.lower()]
+            label = custom_d.get(chunk)
+            hpo_id = self._label_to_id[label.lower()]
             return [HpTerm(id=hpo_id, label=label)]
         else:
             results = []

--- a/pyphetools/creation/hpo_exact_cr.py
+++ b/pyphetools/creation/hpo_exact_cr.py
@@ -64,10 +64,10 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
         return [chunk.strip().lower() for chunk in chunks]
     
     def _parse_chunk(self, chunk, custom_d) -> List[HpTerm]:
-        if chunk in self._label_to_id:
-            hpo_id = self._label_to_id.get(chunk)
+        if chunk in custom_d:
+            hpo_id = custom_d.get(chunk)
             label = self._id_to_primary_label.get(hpo_id)
-            return [HpTerm(id=hpo_id, label=label)]
+            # return [HpTerm(id=hpo_id, label=label)]
         else:
             results = []
             # If we get here, we do two things
@@ -82,14 +82,14 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
                     hpo_label = v
                     hpo_label_lc = hpo_label.lower()    
                     hpo_id = self._label_to_id.get(hpo_label_lc)
-                    if hpo_id is None:
-                        print(f"Unable to retrieve HPO Id for custom mapping {chunk} -> {hpo_label}")
-                        return []
+                    # if hpo_id is None:
+                    #     print(f"Unable to retrieve HPO Id for custom mapping {chunk} -> {hpo_label}")
+                    #     return []
                     results.append(HpTerm(id=hpo_id, label=hpo_label))
                     remaining_text = remaining_text.replace(key, " ")
             # When we get here, we look for HPO terms in the remaining text
             if len(remaining_text) > 5:
-                for k, v in self._label_to_id.items():
+                for k, v in custom_d.items():
                     key = k.lower()
                     if key in remaining_text:
                         hpo_id = v
@@ -117,6 +117,7 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
             for chunk in chunks:
                 # Note that chunk has been stripped of whitespace and lower-cased already
                 res = self._parse_chunk(chunk=chunk, custom_d=custom_d)
+                print(res)
                 results.extend(res)
             return results
 

--- a/pyphetools/creation/hpo_exact_cr.py
+++ b/pyphetools/creation/hpo_exact_cr.py
@@ -65,8 +65,12 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
     
     def _parse_chunk(self, chunk, custom_d) -> List[HpTerm]:
         if chunk in custom_d:
-            label = custom_d.get(chunk)
-            hpo_id = self._label_to_id[label.lower()]
+            if 'hp' not in chunk:
+                hpo_id = custom_d.get(chunk)
+                label = self._id_to_primary_label[hpo_id]
+            else:
+                label = custom_d.get(chunk)
+                hpo_id = self._label_to_id[label.lower()]
             return [HpTerm(id=hpo_id, label=label)]
         else:
             results = []

--- a/pyphetools/creation/hpo_exact_cr.py
+++ b/pyphetools/creation/hpo_exact_cr.py
@@ -65,9 +65,9 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
     
     def _parse_chunk(self, chunk, custom_d) -> List[HpTerm]:
         if chunk in custom_d:
-            hpo_id = custom_d.get(chunk)
-            label = self._id_to_primary_label.get(hpo_id)
-            # return [HpTerm(id=hpo_id, label=label)]
+            label = custom_d.get(chunk)
+            hpo_id = self._label_to_id[label.lower()]
+            return [HpTerm(id=hpo_id, label=label)]
         else:
             results = []
             # If we get here, we do two things
@@ -82,9 +82,9 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
                     hpo_label = v
                     hpo_label_lc = hpo_label.lower()    
                     hpo_id = self._label_to_id.get(hpo_label_lc)
-                    # if hpo_id is None:
-                    #     print(f"Unable to retrieve HPO Id for custom mapping {chunk} -> {hpo_label}")
-                    #     return []
+                    if hpo_id is None:
+                        print(f"Unable to retrieve HPO Id for custom mapping {chunk} -> {hpo_label}")
+                        return []
                     results.append(HpTerm(id=hpo_id, label=hpo_label))
                     remaining_text = remaining_text.replace(key, " ")
             # When we get here, we look for HPO terms in the remaining text
@@ -117,7 +117,6 @@ class HpoExactConceptRecognizer(HpoConceptRecognizer):
             for chunk in chunks:
                 # Note that chunk has been stripped of whitespace and lower-cased already
                 res = self._parse_chunk(chunk=chunk, custom_d=custom_d)
-                print(res)
                 results.extend(res)
             return results
 

--- a/pyphetools/creation/simple_column_mapper.py
+++ b/pyphetools/creation/simple_column_mapper.py
@@ -5,6 +5,29 @@ import pandas as pd
 from collections import defaultdict
 
 
+def get_separate_hpos_from_df(df, hpo_cr):
+    """Loop through all the cells in a dataframe or series and try to parse each cell as HPO term.
+    Useful when the seperate HPO terms are in the cells themselves.
+
+      Args:
+         df (dataframe): dataframe with phenotypic data
+         hpo_cr (HpoConceptRecognizer): instance of HpoConceptRecognizer to match HPO term and get label/id
+
+      Returns:
+          additional_hpos: list of lists with the additional HPO terms per individual
+      """
+    additional_hpos = []
+
+    for i in range(len(df)):
+        temp_hpos = []
+        for y in range(df.shape[1]):
+            hpo_term = hpo_cr.parse_cell(df.iloc[i, y])
+            if len(hpo_term) > 0:
+                temp_hpos.extend(hpo_term)
+        additional_hpos.append(list(set(temp_hpos)))
+    return additional_hpos
+
+
 def try_mapping_columns(df, observed, excluded, hpo_cr, preview=True):
     """Try to map the columns in a dataframe by matching the name of the column to correct HPO term.
     Wrapper for SimpleColumnMapper below


### PR DESCRIPTION
there was a small bug in the HPO parser where the ``custom_d`` was ignored. So if the HPO terms in a column were wrongly parsed, you would get unexpected/unwanted results. For instance 

``
cortex = {'Dysplastic cerebellar cortex': 'Abnormal cerebellar cortex morphology'}
cortexMapper = OptionColumnMapper(concept_recognizer=hpo_cr, option_d=cortex)
print(cortexMapper.preview_column(dft['Cortex']))
column_mapper_d['Cortex'] = cortexMapper
`` 
would lead to ``Renal cortical cysts HP:0000803`` being inserted, while not in the specified dictionary, but some text matched to the standard HPO dict (while this is not renal phenotypic data, but a column about brain imaging)

Furtermore, I wrote a function that I myself find handy, since for _SON_, there were several separate HPO terms in cells, so I added functionality to just loop through a dataframe, collect any HPO terms in a list of lists, and made the encoder accept those.

as always, feel free to change/ignore these 
