### PR TITLE
1&2 used - 'float' object has no attribute 'strip'

### DIFF
--- a/pyphetools/creation/sex_column_mapper.py
+++ b/pyphetools/creation/sex_column_mapper.py
@@ -18,7 +18,7 @@ class SexColumnMapper():
         self._column_name = column_name
     
     def map_cell(self, cell_contents) -> List:
-        contents = cell_contents.strip()
+        contents = str(cell_contents).strip()
         if contents == self._female_symbol:
             return FEMALE_SYMBOL
         elif contents == self._male_symbol:


### PR DESCRIPTION
@pnrobinson 

While creating phenopackets, got the error "'float' object has no attribute 'strip'" when a group used 1 and 2 for Male and Female in their data. This addition would fix the issue. 