### PR TITLE
Fix changed hp.json url

### DIFF
--- a/pyphetools/creation/hpo_parser.py
+++ b/pyphetools/creation/hpo_parser.py
@@ -6,7 +6,7 @@ import urllib.request
 import os
 
 
-HPO_JSON_URL = "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.json"
+HPO_JSON_URL = "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/f99e141f67d79e2521d0f5782be9b2559572128c/hp.json"
 
 
 def extract_curie(url):

--- a/pyphetools/creation/hpo_parser.py
+++ b/pyphetools/creation/hpo_parser.py
@@ -6,7 +6,7 @@ import urllib.request
 import os
 
 
-HPO_JSON_URL = "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/f99e141f67d79e2521d0f5782be9b2559572128c/hp.json"
+HPO_JSON_URL = "http://purl.obolibrary.org/obo/hp/hp.json"
 
 
 def extract_curie(url):


### PR DESCRIPTION
``hp.json`` is not longer in the ``obophenotype`` repo, and so running ``HpoParser()`` fails.

This is a dirty fix: just got the ``hp.json`` from an older commit of that repo.

Probably not what we want long term, but not sure where the ``hp.json`` is hosted right now, I can only find the ``.obo`` files everywhere online.