### PR TITLE
Doc suggestions

### DIFF
--- a/docs/user-guide/cohort_encoder.md
+++ b/docs/user-guide/cohort_encoder.md
@@ -18,7 +18,7 @@ encoder = CohortEncoder(df=dft, hpo_cr=hpo_cr, column_mapper_d=column_mapper_d,
                       pmid=pmid)
 disease_id = "OMIM:618443"
 disease_label = "Neurodevelopmental disorder with or without variable brain abnormalities"
-encoder.set_disease(disease_id=disease_id, label=disease_label)
+encoder.set_disease(Disease(disease_id=disease_id, disease_label=disease_label))
 ```
 
 ### Display a phenopacket

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -51,6 +51,7 @@ from collections import defaultdict
 import re
 from pyphetools.creation import *
 from pyphetools.visualization import PhenopacketTable
+import pyphetools
 print(f"pyphetools version {pyphetools.__version__}")
 ```
 

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -67,7 +67,7 @@ It is useful to import the HPO file and create the MetaData object (which record
 parser = HpoParser()
 hpo_cr = parser.get_hpo_concept_recognizer()
 hpo_version = parser.get_version()
-metadata = MetaData(created_by="ORCID:0000-0002-0736-9199")
+metadata = MetaData(created_by="")
 metadata.default_versions_with_hpo(version=hpo_version)
 ```
 
@@ -80,7 +80,7 @@ hpo_cr = parser.get_hpo_concept_recognizer()
 hpo_version = parser.get_version()
 PMID = "PMID:24736735"
 title = "New insights into genotype-phenotype correlation for GLI3 mutations"
-metadata = MetaData(created_by="ORCID:0000-0002-0736-9199", pmid=PMID, pubmed_title=title)
+metadata = MetaData(created_by="", pmid=PMID, pubmed_title=title)
 metadata.default_versions_with_hpo(version=hpo_version)
 ```
 

--- a/src/pyphetools/creation/option_column_mapper.py
+++ b/src/pyphetools/creation/option_column_mapper.py
@@ -6,6 +6,7 @@ import pandas as pd
 import re
 from collections import defaultdict
 
+
 class OptionColumnMapper(ColumnMapper):
     """Class to map the contents of a table cell to one or more options (HPO terms)
 
@@ -159,7 +160,7 @@ class OptionColumnMapper(ColumnMapper):
         return pd.DataFrame(dlist)
 
     @staticmethod
-    def autoformat(df: pd.DataFrame, concept_recognizer, delimiter=",", omit_columns=None) -> str:
+    def autoformat(df: pd.DataFrame, concept_recognizer, delimiter=",", omit_columns=None, df_name='df') -> str:
         """Autoformat code from the columns so that we can easily copy-paste and change it.
 
         This method intends to save time by preformatting code the create OptionMappers. The following commands
@@ -176,6 +177,8 @@ class OptionColumnMapper(ColumnMapper):
         :type delimiter: str
         :param omit_columns: names of columns to omit from this search
         :type omit_columns: List[str]
+        :param df_name: name of the variable that corresponds to the dataframe
+        :type df_name: str
         :returns: a string that should be displayed using a print() command in the notebook - has info about automatically mapped columns
         :rtype: str
         """
@@ -220,7 +223,7 @@ class OptionColumnMapper(ColumnMapper):
             items_d_string = str(temp_dict).replace(',', ',\n')
             lines.append(f"{items_d_name} = {items_d_string}")
             lines.append(f"{col_name}Mapper = OptionColumnMapper(concept_recognizer=hpo_cr, option_d={items_d_name})")
-            lines.append(f"{col_name}Mapper.preview_column(df['" + str(df.columns[y]) + "'])")
+            lines.append(f"{col_name}Mapper.preview_column({df_name}['" + str(df.columns[y]) + "'])")
             lines.append(f"column_mapper_d['{str(df.columns[y])}'] = {col_name}Mapper")
             lines.append("")
         return "\n".join(lines)


### PR DESCRIPTION
Some minor bugfixes/suggestions for the docs:

- Printing of the  throws an error since the version of pyphetools is printed, without pyphetools being imported
- The docs had an ORCID in them
- There was a minor bug in ``OptionColumnMapper.autoformat``, where the generated text always has df, while for instance if you provide it with dft, it should give you dft in the text as well.
- ``encoder.set_disease(disease_id=disease_id, label=disease_label)`` was faulty, it needs ``Disease``, so ammended that

Hope this helps, feel free to ignore of course